### PR TITLE
Do not track GA at dev env

### DIFF
--- a/shared/routes.jsx
+++ b/shared/routes.jsx
@@ -39,8 +39,13 @@ import Admin                   from 'components/admin/Admin';
 
 import SnlImpact               from 'components/l/SnlImpact';
 
+const env = (process.env.NODE_ENV === "production") ? 'prod' : 'dev'
 
 function loadData() {
+    if (env === "dev") {
+        return; // ga initialize at index.js only for prod
+    }
+
 	if (typeof window !== 'undefined') {
 		const p = window.location.pathname;
 		ReactGA.set({ page: p });


### PR DESCRIPTION
Fixes #317 

**Reason:**
GA trying to track location changes, but client Initialize GA only in the production mode.

**Solution:**
Small code fix approve track GA pages changes only in production mode, because in dev mode it's not initialize ever.