### PR TITLE
Shrink blog content images to the viewport width

### DIFF
--- a/shared/Blog/Components/BlogItem.js
+++ b/shared/Blog/Components/BlogItem.js
@@ -63,7 +63,7 @@ class BlogItem extends React.Component {
 			<div className="blog-item-wrapper">
 				<BlogBreadCrumbs prettyname={prettyname} />
 				{top}
-				<span dangerouslySetInnerHTML={{__html: content}} />
+				<div className="content" dangerouslySetInnerHTML={{__html: content}} />
 				{bot}
 				<MailingListBlogFooter />
 	            <ReactDisqusComments

--- a/shared/styles/pages/_blog.less
+++ b/shared/styles/pages/_blog.less
@@ -10,6 +10,12 @@
   margin: auto;
   clear: both;
   max-width: 600px;
+
+  .content {
+      img {
+        max-width: 100%;
+      }
+  }
 }
 
 .blog-list-container {


### PR DESCRIPTION
Fixes #323 

**Solution:**
Bind all content images width to the parent container width.

**Small issues:**
Blog content could have other media/injectable elements who can be actually bigger then post container, they also should be specified with max width.