### PR TITLE
Shrink long episode title in the episode player

### DIFF
--- a/shared/styles/components/_player.less
+++ b/shared/styles/components/_player.less
@@ -185,6 +185,8 @@
 }
 .thin-player-container .preview .description > p.title {
   color: #575959;
+  overflow-x: hidden;
+  line-height: 20px;
 }
 
 .thin-player-container .slider {


### PR DESCRIPTION
Fixes #428 

<img width="534" alt="screen shot 2018-01-30 at 10 49 39 am" src="https://user-images.githubusercontent.com/20016615/35564034-7763b71c-05c1-11e8-817c-726bdb37a9bb.png">
<img width="502" alt="screen shot 2018-01-30 at 10 49 46 am" src="https://user-images.githubusercontent.com/20016615/35564035-777f939c-05c1-11e8-9ea6-92899b21a5f4.png">
<img width="609" alt="screen shot 2018-01-30 at 10 49 51 am" src="https://user-images.githubusercontent.com/20016615/35564036-779d3eb0-05c1-11e8-8bd0-0421ce381798.png">
