### PR TITLE
Ipinfo cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "classnames": "^2.2.5",
     "compression": "^1.6.2",
     "concurrently": "^3.5.0",
+    "cookie-parser": "^1.4.3",
     "cookie-session": "^2.0.0-beta.3",
     "css-loader": "^0.26.2",
     "echarts": "^4.0.2",

--- a/server.jsx
+++ b/server.jsx
@@ -16,6 +16,7 @@ import {order_list}              from 'backend/order_list'
 import {ready, getTempFile, getFile}  from 'backend/v1/recording';
 import {write as writeProposal, upload as uploadProposalFiles, getRecording}  from 'backend/v1/proposals'
 import bodyParser                from 'body-parser'
+import cookieParser              from 'cookie-parser'
 import compression               from 'compression';
 import {feed_uri}                from 'daos/episodes'
 import {
@@ -254,6 +255,7 @@ if (env == "prod") {
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(cookieParser())
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({
     extended: true
@@ -680,57 +682,97 @@ function renderView(store, renderProps, location) {
     };
 }
 
-function tracking(req) {
-    var ip = "not-set"
+
+/**
+ * You might want to change the response schema.
+ * Please update this key to
+ * have latest request response data in the user session
+ */
+const CURRENT_IP_REQ_VERSION = 0
+
+function getIpData(ip) {
+	return new Promise((resolve, reject) => {
+		request('http://ipinfo.io/' + ip + '?token=' + ipinfo_token, function(error, res, body) {
+				if (body) {
+					try {
+						body = JSON.parse(body)
+						var ip = body['ip']
+						var country = body['country'] || "unknown"
+						var region  = body['region']  || "unknown"
+						var postal  = body['postal']  || "unknown"
+						var loc     = body['loc']     || "unknown"
+						var arr     = loc.split(",")
+						if (arr.length == 2) {
+							var lat = arr[0]
+							var lng = arr[1]
+						} else {
+							var lat = ""
+							var lng = ""
+						}
+						console.log(["influx", lat, region, country, postal])
+
+            var pnt = {
+							measurement: "impression",
+							tags: {country, region, postal},
+							fields: {lat, lng},
+              version: CURRENT_IP_REQ_VERSION
+						}
+
+						resolve(pnt)
+					} catch(err) {
+						console.log("problem with tracking")
+						console.log(err)
+            reject(error)
+					}
+				} else {
+					console.log("Some error from ipinfo.io")
+					console.log(body)
+					console.log(error)
+          reject(error)
+				}
+		})
+  })
+}
+
+async function tracking (req, res) {
+    if (!ipinfo_token) return
+
+    let ip = "not-set"
     if (req.connection) {
         ip = req.connection.remoteAddress
     }
-    if (ipinfo_token) {
-        request('http://ipinfo.io/' + ip + '?token=' + ipinfo_token, function(error, res, body) {
-            if (influxdb) {
-                if (body) {
-		          try {
-                    body = JSON.parse(body)
-                    var ip = body['ip']
-                    var country = body['country'] || "unknown"
-                    var region  = body['region']  || "unknown"
-                    var postal  = body['postal']  || "unknown"
-                    var loc     = body['loc']     || "unknown"
-                    var arr     = loc.split(",")
-                    if (arr.length == 2) {
-                        var lat = arr[0]
-                        var lng = arr[1]
-                    } else {
-                        var lat = ""
-                        var lng = ""
-                    }
-                    console.log(["influx", lat, region, country, postal])
-                    var pnt = {
-                        measurement: "impression",
-                        tags: {country, region, postal},
-                        fields: {lat, lng}
-                    }
-                    influxdb.writePoints([pnt]).then(function() {
-                    }).catch(function (err) {
-                        console.error('Error saving data to InfluxDB!')
-                        console.log(err)
-                    })
-                  } catch(err) {
-                    console.log("problem with tracking")
-                    console.log(err)
-                  }
-                } else {
-                    console.log("Some error from ipinfo.io")
-                    console.log(body)
-                    console.log(error)
-                }
-            }
-        })
+
+	  let ipInfo = req.session.ipInfo
+    if (ipInfo && ipInfo.version !== CURRENT_IP_REQ_VERSION) {
+        ipInfo = null
     }
+
+    if (!ipInfo) {
+        let ipData
+        try {
+            // wait for ip info request data
+            ipData = await getIpData(ip)
+        } catch (err) {}
+
+        // save to current session if not empty
+        if (ipData) {
+	          req.session.ipInfo = ipInfo = ipData
+        }
+    }
+
+    console.log('your ipinfo', ipInfo)
+
+	  if (influxdb) {
+	    return influxdb.writePoints([ipInfo])
+        .then(function() {})
+        .catch(function (err) {
+          console.error('Error saving data to InfluxDB!')
+          console.log(err)
+        })
+	  }
 }
 
-const renderPage = (req, res) => {
-    tracking(req)
+const renderPage = async (req, res) => {
     if (req.url == '/favicon.ico') {
         return res.redirect(301, 'https://s3.amazonaws.com/dataskeptic.com/favicon.ico')
     }
@@ -784,7 +826,14 @@ const renderPage = (req, res) => {
         let store = applyMiddleware(thunk, promiseMiddleware)(createStore)(reducer);
         await updateState(store, location.pathname, req);
 
-        fetchComponentData(store.dispatch, renderProps.components, renderProps.params)
+        /**
+         * I put tracking function after `updateState`.
+         * `updateState` make many requests (to preload state) from the server ip.
+         * I don't see any reason to track "myself".
+         */
+        await tracking(req)
+
+	      fetchComponentData(store.dispatch, renderProps.components, renderProps.params)
             .then(() => renderView(store, renderProps, location))
             .then(({html, state, meta}) => {
                 if (meta.notFoundPage) {

--- a/server.jsx
+++ b/server.jsx
@@ -760,8 +760,6 @@ async function tracking (req, res) {
         }
     }
 
-    console.log('your ipinfo', ipInfo)
-
 	  if (influxdb) {
 	    return influxdb.writePoints([ipInfo])
         .then(function() {})


### PR DESCRIPTION
Fixes #460 

**Changes:**
Store user info in cookie-based session.
_Requires npm i_

**Notes**
If you want to adjust ip info schema in the future, don't forget to update `CURRENT_IP_REQ_VERSION` variable. That will destroy old sessions with old data schema.