### PR TITLE
Align author box at center

### DIFF
--- a/shared/Home/Content/Feature/style.js
+++ b/shared/Home/Content/Feature/style.js
@@ -71,6 +71,8 @@ export const UserDetail = styled.div`
   padding-left: 12px;
   font-size: 14px;
   color: #4a4a4a;
+  align-items: center;
+  display: flex;
 
   a {
     border: none;


### PR DESCRIPTION
Small update to make author box look consistent at home 

now:
<img width="257" alt="screen shot 2018-03-23 at 6 04 27 pm" src="https://user-images.githubusercontent.com/20016615/37840224-2632c568-2ec5-11e8-9fb8-95671b398f64.png">

after updates:
<img width="212" alt="screen shot 2018-03-23 at 6 04 38 pm" src="https://user-images.githubusercontent.com/20016615/37840218-22d3596e-2ec5-11e8-9c7a-ea6983eb9ff7.png">
