### PR TITLE
Player Logic Improvements

### DIFF
--- a/shared/Player/Components/MiniPlayer.js
+++ b/shared/Player/Components/MiniPlayer.js
@@ -4,6 +4,8 @@ import PlayerProgressBar from '../Components/PlayerProgressBar'
 import TogglePlayButton from '../Components/TogglePlayButton'
 import moment from 'moment/moment'
 
+import styled from 'styled-components'
+
 const ignore = e => {
   e.preventDefault()
   e.stopImmediatePropagation()
@@ -26,57 +28,150 @@ export const MiniPlayer = ({
   volumeSlider,
   onClose
 }) => (
-  <div className={cn('thin-player-container', { loading: !loaded })}>
-    <div className="">
-      <div className="col-xs-9 col-sm-4 col-md-3 preview">
-        <img src={preview} alt={title} />
-        <div className="description">
-          <p className="date">{moment(date).format('MMMM D, Y')}</p>
-          <p className="title">{title}</p>
-        </div>
+  <Container className="thin-player-container">
+    <Preview>
+      <img src={preview} alt={title} />
+      <Description>
+        <Date>{moment(date).format('MMMM D, Y')}</Date>
+        <Title>{title}</Title>
+      </Description>
+    </Preview>
+    <Howler>
+      <PlayerProgressBar
+        playing={playing}
+        progress={position}
+        onChange={onSeek}
+        disabled={!loaded}
+      />
+      <div className="player-position-container">
+        <span className="player-position">{realPos}</span>
       </div>
-      <div
-        className={cn('col-xs-4 col-sm-5 col-md-6 slider', {
-          disabled: !loaded
-        })}
-        onClick={e => !loaded && ignore(e)}
-      >
-        <PlayerProgressBar
-          playing={playing}
-          progress={position}
-          onChange={onSeek}
-          disabled={!loaded}
-        />
-        <div className="player-position-container">
-          <span className="player-position">{realPos}</span>
-        </div>
-        <div className="player-duration-container">
-          <span className="player-duration">{duration}</span>
-        </div>
-        {howler}
+      <div className="player-duration-container">
+        <span className="player-duration">{duration}</span>
       </div>
-      <div
-        onClick={e => !loaded && ignore(e)}
-        className={cn('hidden-xs col-sm-2 col-md-2 volume', {
-          disabled: !loaded
-        })}
-      >
-        {volumeSlider}
+      {howler}
+    </Howler>
+    <Volume className="volume">{volumeSlider}</Volume>
+    <Buttons className="button">
+      <TogglePlayButton
+        playing={playing}
+        disabled={!loaded}
+        onClick={onPlayToggle}
+      />
+      <div className="close-player-button-wrapper">
+        <button className="close-player-button" onClick={onClose}>
+          <img src="https://s3.amazonaws.com/dataskeptic.com/img/svg/x.svg" />
+        </button>
       </div>
-      <div className="col-xs-3 col-sm-1 col-md-1 pull-right button">
-        <div className="close-player-button-wrapper">
-          <button className="close-player-button" onClick={onClose}>
-            <img src="https://s3.amazonaws.com/dataskeptic.com/img/svg/x.svg" />
-          </button>
-        </div>
-        <TogglePlayButton
-          playing={playing}
-          disabled={!loaded}
-          onClick={onPlayToggle}
-        />
-      </div>
-    </div>
-  </div>
+    </Buttons>
+  </Container>
 )
 
 export default MiniPlayer
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  height: 64px;
+  background-color: #fff;
+  border-bottom: 1px solid #f1f1f1;
+  box-shadow: 0 1px 15px hsla(0, 0%, 57%, 0.1);
+`
+
+const Preview = styled.div`
+  flex-grow: 2;
+  display: flex;
+  flex-direction: row;
+
+  padding-right: 16px;
+  flex-basis: 250px;
+
+  img {
+    width: 64px;
+    height: 64px;
+  }
+  
+  @media (max-width: 900px) {
+    max-width: 400px;
+  }
+
+  @media (max-width: 760px) {
+    max-width: 200px;
+  }
+`
+
+const Description = styled.div`
+  font-size: 12px;
+  line-height: 14px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  padding-left: 16px;
+  padding-right: 16px;
+
+  width: 100%;
+`
+
+const Date = styled.div`
+  color: #a2a6a6;
+`
+const Title = styled.div`
+  color: #575959;
+  overflow-x: hidden;
+  height: 1em;
+  margin: 0px;
+
+  max-width: 250px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
+
+const Howler = styled.div`
+  margin: 0px 15px;
+  flex-grow: 10;
+
+  @media (max-width: 760px) {
+    position: absolute;
+    padding: 0;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    width: 100%;
+
+    margin: 0px;
+    
+    .player-progress-bar {
+      margin: 0px;
+      padding: 0px;
+    }
+
+    .player-position-container,
+    .player-duration-container {
+      display: none;
+    }
+  }
+`
+
+const Volume = styled.div`
+  flex-grow: 4;
+  margin: 0px 15px;
+  min-height: 20px;
+
+  @media (max-width: 760px) {
+    display: none;
+  }
+`
+
+const Buttons = styled.div`
+  flex-basis: 120px;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+`

--- a/shared/Player/Components/MiniPlayer.js
+++ b/shared/Player/Components/MiniPlayer.js
@@ -90,7 +90,7 @@ const Preview = styled.div`
   flex-basis: 250px;
 
   img {
-    height: 64px;
+    height: 63px;
   }
   
   @media (max-width: 900px) {

--- a/shared/Player/Components/MiniPlayer.js
+++ b/shared/Player/Components/MiniPlayer.js
@@ -90,7 +90,6 @@ const Preview = styled.div`
   flex-basis: 250px;
 
   img {
-    width: 64px;
     height: 64px;
   }
   
@@ -123,7 +122,7 @@ const Date = styled.div`
 const Title = styled.div`
   color: #575959;
   overflow-x: hidden;
-  height: 1em;
+  height: 1.2em;
   margin: 0px;
 
   max-width: 250px;

--- a/shared/Player/Containers/PlayerContainer.js
+++ b/shared/Player/Containers/PlayerContainer.js
@@ -23,6 +23,8 @@ const CAPTURE_TYPES = {
   POS: 'POS'
 }
 
+const normalizeSource = mp3 => mp3.replace('http://', 'https://')
+
 class PlayerContainer extends Component {
   /**
    * Record player action
@@ -231,6 +233,7 @@ class PlayerContainer extends Component {
   }
 
   capture(type, meta = {}) {
+    return
     const { isAuthorized, loggedIn } = this.props
     const uid = v4()
 
@@ -399,6 +402,8 @@ class PlayerContainer extends Component {
     if (mp3s.length > 0) {
       mp3 = mp3s[0]['dest']
       duration = mp3s[0]['duration']
+
+      mp3 = normalizeSource(mp3)
     }
     var img =
       'https://s3.amazonaws.com/dataskeptic.com/img/2017/primary-logo-400.jpg'

--- a/shared/Player/Containers/PlayerContainer.js
+++ b/shared/Player/Containers/PlayerContainer.js
@@ -235,7 +235,6 @@ class PlayerContainer extends Component {
   }
 
   capture(type, meta = {}) {
-    return
     const { isAuthorized, loggedIn } = this.props
     const uid = v4()
 

--- a/shared/Player/Containers/PlayerContainer.js
+++ b/shared/Player/Containers/PlayerContainer.js
@@ -63,7 +63,7 @@ class PlayerContainer extends Component {
     this.updater = setInterval(this.update, 1000)
     setTimeout(() => {
       this.props.dispatch(initializePlayer())
-    }, 300)
+    }, 1300)
   }
 
   componentWillUnmount() {

--- a/shared/Player/Containers/PlayerContainer.js
+++ b/shared/Player/Containers/PlayerContainer.js
@@ -61,7 +61,9 @@ class PlayerContainer extends Component {
     this.setState({ ready: true })
     // start update timer
     this.updater = setInterval(this.update, 1000)
-    this.props.dispatch(initializePlayer())
+    setTimeout(() => {
+      this.props.dispatch(initializePlayer())
+    }, 300)
   }
 
   componentWillUnmount() {

--- a/shared/Player/Containers/VolumeBarContainer.js
+++ b/shared/Player/Containers/VolumeBarContainer.js
@@ -30,7 +30,9 @@ class VolumeBarContainer extends Component {
     const value = volume * 100
     return (
       <div className="volume-bar-container">
-        <VolumeBar onChange={this.onVolumeBarChange} value={value} />
+        {volume !== -1 && (
+          <VolumeBar onChange={this.onVolumeBarChange} value={value} />
+        )}
       </div>
     )
   }

--- a/shared/Player/Containers/VolumeBarContainer.js
+++ b/shared/Player/Containers/VolumeBarContainer.js
@@ -30,7 +30,6 @@ class VolumeBarContainer extends Component {
     const value = volume * 100
     return (
       <div className="volume-bar-container">
-        <VolumeButton silent={muted} onClick={e => this.toggleMute()} />
         <VolumeBar onChange={this.onVolumeBarChange} value={value} />
       </div>
     )

--- a/shared/Podcasts/Components/Episode.js
+++ b/shared/Podcasts/Components/Episode.js
@@ -172,7 +172,7 @@ class Episode extends React.Component {
           </Guests>
         </div>
         <div className="col-xs-12 col-sm-8 episode-middle">
-          <div className="blog-date">{date}</div>
+          <div className="blog-date">{date} | {this.props.episode.blog_id}</div>
           <Title>
             <Link
               className="blog-title no-line"

--- a/shared/reducers/PlayerReducer.js
+++ b/shared/reducers/PlayerReducer.js
@@ -8,7 +8,7 @@ const init = {
   playback_loaded: false,
   position: 0,
   position_updated: false,
-  volume: 0,
+  volume: 0.8,
   muted: false,
   episode: {}
 }
@@ -101,31 +101,35 @@ const removePlaying = () => {
   localStorage.removeItem(PLAYER_META_KEY)
 }
 
-const getCachePlaying = (nstate) => {
+const getCachePlaying = nstate => {
   const episodeData = getKey(PLAYER_PLAYING_KEY)
   const episodeMeta = getPlayingMeta(episodeData)
-  
+
   if (isEmpty(episodeMeta)) {
     return nstate
-  } 
-  
-  if (!episodeMeta.has_shown) {
-    return nstate
   }
-  
+
+  const volume = episodeMeta.volume || 0.8
+
+  if (!episodeMeta.has_shown) {
+    return {
+      ...nstate,
+      volume
+    }
+  }
+
   delete episodeMeta.has_shown
   delete episodeMeta.is_playing
   delete episodeMeta.blog_id
 
   nstate = playEpisode(nstate, episodeData)
-  const volume = (episodeMeta.volume || 0.8)
-  
+
   nstate = {
     ...nstate,
     ...episodeMeta,
     volume
   }
-  
+
   return nstate
 }
 

--- a/shared/reducers/PlayerReducer.js
+++ b/shared/reducers/PlayerReducer.js
@@ -32,13 +32,15 @@ const normalizeState = ({
   position = 0,
   episode = null,
   volume = 0.8,
-  muted = false
+  muted = false,
+  has_shown = false
 }) => ({
   is_playing,
   position,
   episode,
   volume,
-  muted
+  muted,
+  has_shown
 })
 
 const getKey = key => {
@@ -119,7 +121,6 @@ const getCachePlaying = nstate => {
   }
 
   delete episodeMeta.has_shown
-  delete episodeMeta.is_playing
   delete episodeMeta.blog_id
 
   nstate = playEpisode(nstate, episodeData)
@@ -127,7 +128,8 @@ const getCachePlaying = nstate => {
   nstate = {
     ...nstate,
     ...episodeMeta,
-    volume
+    volume,
+    is_playing: episodeMeta.is_playing || false
   }
 
   return nstate

--- a/shared/reducers/PlayerReducer.js
+++ b/shared/reducers/PlayerReducer.js
@@ -8,7 +8,7 @@ const init = {
   playback_loaded: false,
   position: 0,
   position_updated: false,
-  volume: 0.8,
+  volume: -1,
   muted: false,
   episode: {}
 }
@@ -155,6 +155,10 @@ const playEpisode = (nstate, episode) => {
   nstate.playback_loaded = false
   nstate.is_playing = true
   nstate.has_shown = true
+  
+  if (nstate.volume) {
+    nstate.volume = 0.8
+  }
 
   return nstate
 }
@@ -247,6 +251,7 @@ export default function PlayerReducer(state = defaultState, action) {
 
     case SET_MUTED:
       nstate.muted = action.payload.muted
+      savePlayingMeta(nstate)
       break
 
     case 'PLAYBACK_LOADED':
@@ -276,6 +281,7 @@ export default function PlayerReducer(state = defaultState, action) {
 
     case SET_VOLUME:
       nstate.volume = action.payload.volume
+      savePlayingMeta(nstate)
       break
 
     case RESET:

--- a/shared/reducers/PlayerReducer.js
+++ b/shared/reducers/PlayerReducer.js
@@ -156,7 +156,7 @@ const playEpisode = (nstate, episode) => {
   nstate.is_playing = true
   nstate.has_shown = true
   
-  if (nstate.volume) {
+  if (!nstate.volume || nstate.volume === -1) {
     nstate.volume = 0.8
   }
 

--- a/shared/styles/components/_player.less
+++ b/shared/styles/components/_player.less
@@ -313,8 +313,6 @@
 }
 
 .volume {
-  padding: 22px 10px;
-
   .volume-button {
     left: -34px;
     position: relative;

--- a/shared/styles/components/_player.less
+++ b/shared/styles/components/_player.less
@@ -316,6 +316,9 @@
   padding: 22px 10px;
 
   .volume-button {
+    left: -34px;
+    position: relative;
+
     width: 20px;
     height: 20px;
     background: transparent;
@@ -339,7 +342,6 @@
   }
 
   .volume-slider-container {
-    margin-left: 40px;
     padding: 9px;
     position: relative;
 

--- a/shared/styles/layout/_header.less
+++ b/shared/styles/layout/_header.less
@@ -130,8 +130,8 @@
   }
 
   .header .nav .navlink-li-container {
-    margin-right: 12px;
-    margin-left: 12px;
+    margin-right: 5px;
+    margin-left: 5px;
   }
 
   #logo_desktop {

--- a/shared/styles/layout/_header.less
+++ b/shared/styles/layout/_header.less
@@ -36,8 +36,8 @@
 
 @media only screen and (max-width: 1020px) {
   .header .nav .navlink-li-container {
-    margin-left: 15px;
-    margin-right: 15px;
+    margin-left: 12px;
+    margin-right: 12px;
   }
 }
 


### PR DESCRIPTION
Fixes #714, #716, #715 

This is small but important player update I'd like to describe fully.

1. _Responsive layout for mini player_

Resolved wrapping issue, improved layout rendering performance.
<details><summary>See in action (GIF)</summary><p>

![mcfx7w3inv](https://user-images.githubusercontent.com/20016615/40788451-c58573cc-64f8-11e8-98d6-c13886745c17.gif)

---
</p></details>
<hr>
2. _Forcing httpS mannualy in the player_ 

`PlayerContainer` directly replace mp3 link to be sure 
<hr>
3. _Improved position memorization logic_

From now we memorize player position for each episode. In other words, user going to listen the episode from the previous position with global site config (`volume level` for now)

<details><summary>Switching episodes demo (GIF)</summary><p>

![thk26vztru](https://user-images.githubusercontent.com/20016615/40788932-e5083d0a-64f9-11e8-9654-ce6d194c22b3.gif)

---
</p></details>

<hr>

4. Improved `x` logic

There is a few cases of x logic:

– User listen the episode and refresh/close the page
On back, user see the player on the same state (playing, position, volume)

– User listen the episode and pause it
Site will show again the player with `pause` mode with the same config

– User listen the episode and click `x`
Site will memorize volume level, but will not show the player on back.


<details><summary>Refreshing the page cases demo (GIF)</summary><p>

![rkfqisbth0](https://user-images.githubusercontent.com/20016615/40789437-182f40a6-64fb-11e8-9744-47ee046d3d74.gif)

---
</p></details>

<hr>

Note: Maybe, I'm expect to have some issues with bonus audio episodes, wich also use the mini player, so let's test this case as well
